### PR TITLE
Generalize file path seperator

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -69,10 +69,8 @@ class Main {
 
     this.filePath = file;
 
-    var slash = '\\';
-    if (process.platform === 'darwin') {
-      slash = '/';
-    }
+    const slash = p.sep;
+
     this.workingDir = this.filePath.substring(
       0,
       this.filePath.lastIndexOf(slash)


### PR DESCRIPTION
Change the way file path separator is defined so files/directories can also be accessed on platforms other than windows and mac os.

