### PR TITLE
Persistence storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "cross-env NODE_ENV=development electron ./src/",
-    "test": "mocha"
+    "test": "jest",
+    "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
     "create-react-class": "^15.6.3",
@@ -36,6 +37,6 @@
     "electron-react-devtools": "^0.3.1",
     "electron-reload": "^1.5.0",
     "expect": "^24.9.0",
-    "mocha": "^6.2.2"
+    "jest": "^24.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "cross-env NODE_ENV=development electron ./src/",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "dependencies": {
     "create-react-class": "^15.6.3",
@@ -34,6 +34,8 @@
     "electron-devtools-installer": "^2.0.1",
     "electron-packager": "^14.1.0",
     "electron-react-devtools": "^0.3.1",
-    "electron-reload": "^1.5.0"
+    "electron-reload": "^1.5.0",
+    "expect": "^24.9.0",
+    "mocha": "^6.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-test",
+  "name": "idyll-studio",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -9,31 +9,31 @@
   "dependencies": {
     "create-react-class": "^15.6.3",
     "draft-js": "^0.10.5",
-    "electron": "^4.0.1",
-    "idyll": "^4.3.2",
-    "idyll-compiler": "^4.0.7",
-    "idyll-components": "^3.6.2",
-    "idyll-document": "^3.0.6",
-    "react": "^16.0.0",
+    "electron": "^4.2.12",
+    "idyll": "^4.8.0",
+    "idyll-compiler": "^4.0.12",
+    "idyll-components": "^3.11.1",
+    "idyll-document": "^3.1.8",
+    "react": "^16.11.0",
     "react-data-grid": "^6.1.0",
-    "react-dnd": "^7.4.5",
-    "react-dnd-html5-backend": "^7.4.4",
-    "react-dom": "^16.0.0",
+    "react-dnd": "^7.7.0",
+    "react-dnd-html5-backend": "^7.7.0",
+    "react-dom": "^16.11.0",
     "react-select": "^2.3.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@babel/preset-env": "^7.2.3",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/core": "^7.7.2",
+    "@babel/plugin-proposal-class-properties": "^7.7.0",
+    "@babel/preset-env": "^7.7.1",
+    "@babel/preset-react": "^7.7.0",
     "@babel/preset-stage-2": "^7.0.0",
-    "@babel/register": "^7.0.0",
-    "acorn": "^6.0.5",
+    "@babel/register": "^7.7.0",
+    "acorn": "^6.3.0",
     "cross-env": "^3.1.4",
     "electron-connect": "*",
     "electron-devtools-installer": "^2.0.1",
-    "electron-packager": "*",
+    "electron-packager": "^14.1.0",
     "electron-react-devtools": "^0.3.1",
-    "electron-reload": "^1.3.0"
+    "electron-reload": "^1.5.0"
   }
 }

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -8,6 +8,7 @@ class DataStore {
     const userDataPath = (electron.app || electron.remote.app).getPath(
       'userData'
     );
+    console.log(userDataPath);
 
     this.path = path.join(userDataPath, 'project-data.json');
 
@@ -16,25 +17,27 @@ class DataStore {
     } catch (error) {
       console.log('Creating a new store...');
       this.data = defaultData;
+      updateFile(this.path, this.data);
     }
   }
 
   // get url by token
   getUrlByToken(inputToken) {
-    return this.data.tokenUrls.filter(
+    return this.data['tokenUrls'].filter(
       tokenUrlMap => tokenUrlMap.token === inputToken
     );
   }
 
   // get last session
   getLastSessionProjectPath() {
-    return this.data.lastOpenedProject.filePath;
+    const lastProject = this.data.lastOpenedProject['filePath'];
+    return lastProject ? lastProject : null;
   }
 
   // add url and token
   addNewUrlTokenPair(url, token) {
     let dataClone = { ...this.data };
-    dataClone.tokenUrls.push({ token: token, url: url });
+    dataClone['tokenUrls'].push({ token: token, url: url });
 
     this.data = dataClone;
 
@@ -44,10 +47,11 @@ class DataStore {
 
   // update / put session
   updateLastOpenedProject(projectPath) {
-    this.data = {
-      ...this.data,
-      lastOpenedProject: { filePath: projectPath, lastOpened: Date.now() }
-    };
+    let dataClone = { ...this.data };
+    dataClone.lastOpenedProject['filePath'] = projectPath;
+    dataClone.lastOpenedProject['lastOpened'] = Date.now();
+
+    this.data = dataClone;
 
     updateFile(this.path, JSON.stringify(this.data));
   }
@@ -55,9 +59,10 @@ class DataStore {
 
 function updateFile(path, contents) {
   try {
+    console.log('Updating file...', path, contents);
     fs.writeFileSync(path, contents);
   } catch (error) {
-    console.log('Error saving url and publishing token: ', error);
+    console.log('Error: ', error);
   }
 }
 

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -8,7 +8,6 @@ class DataStore {
     const userDataPath = (electron.app || electron.remote.app).getPath(
       'userData'
     );
-    console.log(userDataPath);
 
     this.path = path.join(userDataPath, 'project-data.json');
 
@@ -23,9 +22,11 @@ class DataStore {
 
   // get url by token
   getTokenUrlByToken(inputToken) {
-    return this.data['tokenUrls'].filter(
+    const tokenUrl = this.data['tokenUrls'].filter(
       tokenUrlMap => tokenUrlMap.token === inputToken
     )[0];
+
+    return tokenUrl;
   }
 
   // get last session
@@ -64,6 +65,7 @@ class DataStore {
   }
 }
 
+// Given a file path and the contents to write, updates the file
 function updateFile(path, contents) {
   try {
     console.log('Updating file...', contents);

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -66,7 +66,7 @@ class DataStore {
 
 function updateFile(path, contents) {
   try {
-    console.log('Updating file...', path, contents);
+    console.log('Updating file...', contents);
     fs.writeFileSync(path, contents);
   } catch (error) {
     console.log('Error: ', error);

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -22,10 +22,10 @@ class DataStore {
   }
 
   // get url by token
-  getUrlByToken(inputToken) {
+  getTokenUrlByToken(inputToken) {
     return this.data['tokenUrls'].filter(
       tokenUrlMap => tokenUrlMap.token === inputToken
-    );
+    )[0];
   }
 
   // get last session
@@ -35,14 +35,21 @@ class DataStore {
   }
 
   // add url and token
-  addNewUrlTokenPair(url, token) {
-    let dataClone = { ...this.data };
-    dataClone['tokenUrls'].push({ token: token, url: url });
+  addTokenUrlPair(url, token) {
+    const existingToken = this.getTokenUrlByToken(token);
+    console.log('Checking for token pair...', existingToken);
 
-    this.data = dataClone;
+    if (!existingToken) {
+      console.log('Adding new token pair...');
+      let dataClone = { ...this.data };
 
-    // serialize data back to file
-    updateFile(this.path, JSON.stringify(this.data));
+      dataClone['tokenUrls'].push({ token: token, url: url });
+
+      this.data = dataClone;
+
+      // serialize data back to file
+      updateFile(this.path, JSON.stringify(this.data));
+    }
   }
 
   // update / put session

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -1,0 +1,64 @@
+const electron = require('electron');
+const fs = require('fs');
+const path = require('path');
+// Reference: https://github.com/ccnokes/electron-tutorials/blob/master/storing-data/store.js
+
+class DataStore {
+  constructor(defaultData) {
+    const userDataPath = (electron.app || electron.remote.app).getPath(
+      'userData'
+    );
+
+    this.path = path.join(userDataPath, 'project-data.json');
+
+    try {
+      this.data = JSON.parse(fs.readFileSync(this.path));
+    } catch (error) {
+      console.log('Creating a new store...');
+      this.data = defaultData;
+    }
+  }
+
+  // get url by token
+  getUrlByToken(inputToken) {
+    return this.data.tokenUrls.filter(
+      tokenUrlMap => tokenUrlMap.token === inputToken
+    );
+  }
+
+  // get last session
+  getLastSessionProjectPath() {
+    return this.data.lastOpenedProject.filePath;
+  }
+
+  // add url and token
+  addNewUrlTokenPair(url, token) {
+    let dataClone = { ...this.data };
+    dataClone.tokenUrls.push({ token: token, url: url });
+
+    this.data = dataClone;
+
+    // serialize data back to file
+    updateFile(this.path, JSON.stringify(this.data));
+  }
+
+  // update / put session
+  updateLastOpenedProject(projectPath) {
+    this.data = {
+      ...this.data,
+      lastOpenedProject: { filePath: projectPath, lastOpened: Date.now() }
+    };
+
+    updateFile(this.path, JSON.stringify(this.data));
+  }
+}
+
+function updateFile(path, contents) {
+  try {
+    fs.writeFileSync(path, contents);
+  } catch (error) {
+    console.log('Error saving url and publishing token: ', error);
+  }
+}
+
+module.exports = DataStore;

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -38,10 +38,8 @@ class DataStore {
   // add url and token
   addTokenUrlPair(url, token) {
     const existingToken = this.getTokenUrlByToken(token);
-    console.log('Checking for token pair...', existingToken);
 
     if (!existingToken) {
-      console.log('Adding new token pair...');
       let dataClone = { ...this.data };
 
       dataClone['tokenUrls'].push({ token: token, url: url });

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,14 @@
+class ExtendableError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = this.constructor.name;
+    this.message = msg;
+    this.stack = new Error(msg).stack;
+  }
+}
+
+exports.InvalidParameterError = class InvalidParameterError extends ExtendableError {
+  constructor(msg) {
+    super(msg);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
-const {app, BrowserWindow} = require('electron');
+const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const url = require('url');
 const Main = require('./main/main.js');
+const DataStore = require('./data-store');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let win
+let win;
 
-function createWindow () {
+function createWindow() {
   // Create the browser window.
   win = new BrowserWindow({
     width: 1300,
@@ -15,24 +16,28 @@ function createWindow () {
     minWidth: 600,
     minHeight: 400,
     title: 'electron-compile-react'
-  })
+  });
 
   // load the index.html of the app based on script ENV Variables.
   if (process.env.NODE_ENV === 'development') {
-    win.loadURL(url.format({
-      pathname: path.join(__dirname, 'index.html'),
-      protocol: 'file:',
-      slashes: true
-    }))
+    win.loadURL(
+      url.format({
+        pathname: path.join(__dirname, 'index.html'),
+        protocol: 'file:',
+        slashes: true
+      })
+    );
 
     // Open the DevTools only in Development mode.
-    win.webContents.openDevTools()
+    win.webContents.openDevTools();
   } else {
-    win.loadURL(url.format({
-      pathname: path.join(__dirname, 'index.html'),
-      protocol: 'file:',
-      slashes: true
-    }))
+    win.loadURL(
+      url.format({
+        pathname: path.join(__dirname, 'index.html'),
+        protocol: 'file:',
+        slashes: true
+      })
+    );
   }
 
   // Emitted when the window is closed.
@@ -40,35 +45,47 @@ function createWindow () {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    win = null
-  })
+    win = null;
+  });
 
-  new Main({app, win});
+  const store = new DataStore({
+    tokenUrls: [],
+    lastOpenedProject: { filePath: null, lastOpened: null }
+  });
+
+  const existingProjectPath = getExistingProject(store);
+
+  new Main({ app, win, store, existingProjectPath });
 }
-
-
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', createWindow);
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (win === null) {
-    createWindow()
+    createWindow();
   }
-})
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+function getExistingProject(store) {
+  const lastOpenedProject = store.getLastSessionProjectPath();
+  if (lastOpenedProject) {
+    console.log('Opening up existing project...', lastOpenedProject);
+  }
+  return lastOpenedProject;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ function createWindow() {
 
   const main = new Main({ app, win, store });
 
+  // When everything is ready to load, show window
   win.once('ready-to-show', () => {
     const existingProjectPath = getExistingProject(store);
     if (existingProjectPath) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const url = require('url');
 const Main = require('./main/main.js');
-const DataStore = require('./data-store');
+const DataStore = require('./main/data-store/data-store');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -19,10 +19,7 @@ function createWindow() {
     show: false
   });
 
-  const store = new DataStore({
-    tokenUrls: [],
-    lastOpenedProject: { filePath: null, lastOpened: null }
-  });
+  const store = new DataStore();
 
   const main = new Main({ app, win, store });
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,23 @@ function createWindow() {
     height: 1000,
     minWidth: 600,
     minHeight: 400,
-    title: 'electron-compile-react'
+    title: 'electron-compile-react',
+    show: false
+  });
+
+  const store = new DataStore({
+    tokenUrls: [],
+    lastOpenedProject: { filePath: null, lastOpened: null }
+  });
+
+  const main = new Main({ app, win, store });
+
+  win.once('ready-to-show', () => {
+    const existingProjectPath = getExistingProject(store);
+    if (existingProjectPath) {
+      main.executeOnProjectOpen(existingProjectPath);
+    }
+    win.show();
   });
 
   // load the index.html of the app based on script ENV Variables.
@@ -47,15 +63,6 @@ function createWindow() {
     // when you should delete the corresponding element.
     win = null;
   });
-
-  const store = new DataStore({
-    tokenUrls: [],
-    lastOpenedProject: { filePath: null, lastOpened: null }
-  });
-
-  const existingProjectPath = getExistingProject(store);
-
-  new Main({ app, win, store, existingProjectPath });
 }
 
 // This method will be called when Electron has finished

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function createWindow() {
 
   // When everything is ready to load, show window
   win.once('ready-to-show', () => {
-    const existingProjectPath = getExistingProject(store);
+    const existingProjectPath = store.getLastSessionProjectPath();
     if (existingProjectPath) {
       main.executeOnProjectOpen(existingProjectPath);
     }
@@ -90,10 +90,3 @@ app.on('activate', () => {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
-function getExistingProject(store) {
-  const lastOpenedProject = store.getLastSessionProjectPath();
-  if (lastOpenedProject) {
-    console.log('Opening up existing project...', lastOpenedProject);
-  }
-  return lastOpenedProject;
-}

--- a/src/main/data-store/data-store.js
+++ b/src/main/data-store/data-store.js
@@ -23,7 +23,7 @@ class DataStore {
     } catch (error) {
       console.log(error, 'Creating a new store...');
       this.data = defaultData;
-      updateFile(this.path, this.data);
+      updateFile(this.path, JSON.stringify(this.data));
     }
   }
 
@@ -34,11 +34,7 @@ class DataStore {
    * @param {string} inputToken the .idyll token contents
    */
   getTokenUrlByToken(inputToken) {
-    if (!inputToken) {
-      throw new error.InvalidParameterError(
-        'Input token must not be null or undefined'
-      );
-    }
+    checkParams(inputToken, 'inputToken');
 
     const tokenUrl = this.data['tokenUrls'].filter(
       tokenUrlMap => tokenUrlMap.token === inputToken
@@ -63,15 +59,8 @@ class DataStore {
    * @param {string} token the corresponding token string
    */
   addTokenUrlPair(url, token) {
-    if (!url) {
-      throw new error.InvalidParameterError(
-        'Url must not be null or undefined'
-      );
-    } else if (!token) {
-      throw new error.InvalidParameterError(
-        'Token must not be null or undefined'
-      );
-    }
+    checkParams(url, 'url');
+    checkParams(token, 'token');
 
     const existingToken = this.getTokenUrlByToken(token);
 
@@ -97,11 +86,7 @@ class DataStore {
    * @param {string} projectPath
    */
   updateLastOpenedProject(projectPath) {
-    if (!projectPath) {
-      throw new error.InvalidParameterError(
-        'Project path must not be null or undefined'
-      );
-    }
+    checkParams(projectPath, 'projectPath');
 
     const tokenUrls = getDeepCopyOfTokenUrls(this.data.tokenUrls);
     const lastOpenedProject = { filePath: projectPath, lastOpened: Date.now() };
@@ -128,7 +113,6 @@ function updateFile(path, contents) {
     fs.writeFileSync(path, contents);
   } catch (error) {
     console.log(error);
-    throw error;
   }
 }
 
@@ -140,6 +124,14 @@ function getDeepCopyOfTokenUrls(tokenUrls) {
   return tokenUrls.map(tokenUrl => ({
     ...tokenUrl
   }));
+}
+
+function checkParams(input, inputName) {
+  if (!input) {
+    throw new error.InvalidParameterError(
+      inputName + ' must not be null or undefined'
+    );
+  }
 }
 
 module.exports = DataStore;

--- a/src/main/data-store/data-store.js
+++ b/src/main/data-store/data-store.js
@@ -1,6 +1,8 @@
 const electron = require('electron');
 const fs = require('fs');
 const path = require('path');
+const error = require('../../error');
+
 // Reference: https://github.com/ccnokes/electron-tutorials/blob/master/storing-data/store.js
 
 class DataStore {
@@ -19,7 +21,7 @@ class DataStore {
     try {
       this.data = JSON.parse(fs.readFileSync(this.path));
     } catch (error) {
-      console.log('Creating a new store...');
+      console.log(error, 'Creating a new store...');
       this.data = defaultData;
       updateFile(this.path, this.data);
     }
@@ -32,9 +34,9 @@ class DataStore {
    * @param {string} inputToken the .idyll token contents
    */
   getTokenUrlByToken(inputToken) {
-    if (inputToken === null || inputToken === undefined) {
-      throw new InvalidParameterError(
-        'Input token should not be null or undefined.'
+    if (!inputToken) {
+      throw new error.InvalidParameterError(
+        'Input token must not be null or undefined'
       );
     }
 
@@ -61,10 +63,14 @@ class DataStore {
    * @param {string} token the corresponding token string
    */
   addTokenUrlPair(url, token) {
-    if (url === null || url === undefined) {
-      throw new InvalidParameterError('Url must not be null or undefined.');
-    } else if (token === null || token === undefined) {
-      throw new InvalidParameterError('Token must not be null or undefined');
+    if (!url) {
+      throw new error.InvalidParameterError(
+        'Url must not be null or undefined'
+      );
+    } else if (!token) {
+      throw new error.InvalidParameterError(
+        'Token must not be null or undefined'
+      );
     }
 
     const existingToken = this.getTokenUrlByToken(token);
@@ -91,9 +97,9 @@ class DataStore {
    * @param {string} projectPath
    */
   updateLastOpenedProject(projectPath) {
-    if (projectPath === null || projectPath === undefined) {
-      throw new InvalidParameterError(
-        'Project path must not be null or undefined.'
+    if (!projectPath) {
+      throw new error.InvalidParameterError(
+        'Project path must not be null or undefined'
       );
     }
 

--- a/src/main/data-store/data-store.js
+++ b/src/main/data-store/data-store.js
@@ -4,7 +4,12 @@ const path = require('path');
 // Reference: https://github.com/ccnokes/electron-tutorials/blob/master/storing-data/store.js
 
 class DataStore {
-  constructor(defaultData) {
+  constructor(
+    defaultData = {
+      tokenUrls: [],
+      lastOpenedProject: { filePath: null, lastOpened: null }
+    }
+  ) {
     const userDataPath = (electron.app || electron.remote.app).getPath(
       'userData'
     );
@@ -27,8 +32,10 @@ class DataStore {
    * @param {string} inputToken the .idyll token contents
    */
   getTokenUrlByToken(inputToken) {
-    if (!inputToken) {
-      throw new Error('Input token should not be null or undefined.');
+    if (inputToken === null || inputToken === undefined) {
+      throw new InvalidParameterError(
+        'Input token should not be null or undefined.'
+      );
     }
 
     const tokenUrl = this.data['tokenUrls'].filter(
@@ -54,8 +61,10 @@ class DataStore {
    * @param {string} token the corresponding token string
    */
   addTokenUrlPair(url, token) {
-    if (!url || !token) {
-      throw new Error('Url and token must not be null or undefined.');
+    if (url === null || url === undefined) {
+      throw new InvalidParameterError('Url must not be null or undefined.');
+    } else if (token === null || token === undefined) {
+      throw new InvalidParameterError('Token must not be null or undefined');
     }
 
     const existingToken = this.getTokenUrlByToken(token);
@@ -82,8 +91,10 @@ class DataStore {
    * @param {string} projectPath
    */
   updateLastOpenedProject(projectPath) {
-    if (!projectPath) {
-      throw new Error('Project path must not be null or undefined.');
+    if (projectPath === null || projectPath === undefined) {
+      throw new InvalidParameterError(
+        'Project path must not be null or undefined.'
+      );
     }
 
     const tokenUrls = getDeepCopyOfTokenUrls(this.data.tokenUrls);
@@ -100,7 +111,11 @@ class DataStore {
   }
 }
 
-// Given a file path and the contents to write, updates the file
+/**
+ * Updates the data store file with the current data
+ * @param {string} path the file path for the project
+ * @param {string} contents the data contents
+ */
 function updateFile(path, contents) {
   try {
     console.log('Updating file...', contents);
@@ -111,8 +126,10 @@ function updateFile(path, contents) {
   }
 }
 
-// Helper function that returns deep copy of
-// token urls
+/**
+ * Returns a deep copy of the tokenUrl list
+ * @param {string} tokenUrls the list of tokenUrl objects
+ */
 function getDeepCopyOfTokenUrls(tokenUrls) {
   return tokenUrls.map(tokenUrl => ({
     ...tokenUrl

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -8,7 +8,6 @@ const request = require('request-promise-native');
 const urljoin = require('url-join');
 const IDYLL_PUB_API = 'https://api.idyll.pub';
 const compile = require('idyll-compiler');
-const DataStore = require('../data-store');
 
 class Main {
   constructor(electronObjects) {
@@ -16,22 +15,6 @@ class Main {
     const menu = new Menu(electronObjects);
 
     this.store = electronObjects.store;
-
-    if (electronObjects.existingProjectPath) {
-      // this.filePath = electronObjects.existingProjectPath;
-      // this.workingDir = getWorkingDirectory(this.filePath);
-
-      // // Instantiate an Idyll instance
-      // this.idyll = Idyll({
-      //   inputFile: this.filePath,
-      //   output: this.workingDir + '/build/',
-      //   componentFolder: this.workingDir + '/components/',
-      //   dataFolder: this.workingDir + '/data',
-      //   layout: 'centered',
-      //   theme: 'default'
-      // });
-      this.executeOnProjectOpen(electronObjects.existingProjectPath);
-    }
 
     this.electronWorkingDir = require('path').dirname(require.main.filename);
 
@@ -173,11 +156,6 @@ class Main {
   executeOnProjectOpen(file) {
     this.filePath = file;
 
-    // const slash = p.sep;
-    // this.workingDir = this.filePath.substring(
-    //   0,
-    //   this.filePath.lastIndexOf(slash)
-    // );
     this.workingDir = getWorkingDirectory(this.filePath);
 
     // Instantiate an Idyll instance

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -198,7 +198,6 @@ class Main {
       fileContent = fs.readFileSync(file).toString();
     } catch (err) {
       console.log(err);
-      // handle this in the UI somehow?
     }
 
     // Compile contents

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -198,11 +198,24 @@ class Main {
     // Compile contents
     compile(fileContent, {})
       .then(ast => {
+        const tokenPath = getTokenPath(this.workingDir);
+        let url;
+        try {
+          const token = fs.readFileSync(tokenPath, { encoding: 'utf-8' });
+          url = this.store.getTokenUrlByToken(token).url;
+
+          console.log('retrieved url successfully', url);
+        } catch (error) {
+          url = '';
+          console.log(error, 'Token does not exist yet.');
+        }
+
         this.mainWindow.webContents.send('idyll:compile', {
           ast: ast,
           path: this.filePath,
           components: this.idyll.getComponents(),
-          datasets: this.idyll.getDatasets()
+          datasets: this.idyll.getDatasets(),
+          url: url
         });
       })
       .catch(error => {
@@ -210,20 +223,6 @@ class Main {
       });
 
     this.store.updateLastOpenedProject(this.filePath);
-
-    const tokenPath = getTokenPath(this.workingDir);
-    try {
-      const token = fs.readFileSync(tokenPath, { encoding: 'utf-8' });
-      const url = this.store.getTokenUrlByToken(token).url;
-
-      console.log('retrieved url successfully', url);
-      this.mainWindow.webContents.send('url', {
-        url: url,
-        status: 'published'
-      });
-    } catch (error) {
-      console.log(error, 'Token does not exist yet.');
-    }
   }
 }
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -55,8 +55,7 @@ class Main {
       properties: ['openFile'],
       filters: [
         {
-          // Give a specific filter on what
-          // type of files we are looking for
+          // Give a specific filter on acceptable file types
           name: 'Idyll',
           extensions: ['idyll', 'idl']
         }
@@ -93,7 +92,6 @@ class Main {
 
   async publish() {
     const projectDir = this.workingDir;
-    // const tokenPath = p.join(projectDir, '.idyll', 'token');
     const tokenPath = getTokenPath(p, projectDir);
     const config = require(p.join(projectDir, 'package.json'));
     try {
@@ -197,8 +195,14 @@ class Main {
       }
     );
 
-    // Accepts a file path
-    const fileContent = fs.readFileSync(file).toString();
+    // Serialize file contents
+    let fileContent = '';
+    try {
+      fileContent = fs.readFileSync(file).toString();
+    } catch (err) {
+      console.log(err);
+      // handle this in the UI somehow?
+    }
 
     // Compile contents
     compile(fileContent, {})
@@ -213,9 +217,10 @@ class Main {
           if (tokenUrl) {
             url = tokenUrl.url;
           } else {
+            // TODO: Get URL from idyll pub api here
             console.log('Make request to server for url since token exists');
+            // url = await request.get({ url: IDYLL_PUB_API/{token} })
           }
-          this.mainWindow.webContents.send('loading-project');
         } catch (error) {
           console.log(error, 'Token does not exist yet.');
         }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -92,7 +92,7 @@ class Main {
 
   async publish() {
     const projectDir = this.workingDir;
-    const tokenPath = getTokenPath(projectDir);
+    const tokenPath = getTokenPath(p, projectDir);
     const config = require(p.join(projectDir, 'package.json'));
     try {
       let buildDir = p.join(projectDir, 'build');
@@ -157,7 +157,7 @@ class Main {
   executeOnProjectOpen(file) {
     this.filePath = file;
 
-    this.workingDir = getWorkingDirectory(this.filePath);
+    this.workingDir = getWorkingDirectory(p, this.filePath);
 
     // Instantiate an Idyll instance
     this.idyll = Idyll({
@@ -205,7 +205,7 @@ class Main {
     compile(fileContent, {})
       .then(ast => {
         // Get project URL if it exists
-        const tokenPath = getTokenPath(this.workingDir);
+        const tokenPath = getTokenPath(p, this.workingDir);
 
         let url = '';
         try {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -92,7 +92,7 @@ class Main {
 
   async publish() {
     const projectDir = this.workingDir;
-    const tokenPath = getTokenPath(p, projectDir);
+    const tokenPath = getTokenPath(projectDir);
     const config = require(p.join(projectDir, 'package.json'));
     try {
       let buildDir = p.join(projectDir, 'build');
@@ -115,10 +115,7 @@ class Main {
       const url = `https://idyll.pub/post/${alias}/`;
 
       // Send to render process the url
-      this.mainWindow.webContents.send('published-url', {
-        url: url,
-        status: 'published'
-      });
+      this.mainWindow.webContents.send('published-url', url);
 
       this.store.addTokenUrlPair(url, token);
     } catch (err) {
@@ -160,7 +157,7 @@ class Main {
   executeOnProjectOpen(file) {
     this.filePath = file;
 
-    this.workingDir = getWorkingDirectory(p, this.filePath);
+    this.workingDir = getWorkingDirectory(this.filePath);
 
     // Instantiate an Idyll instance
     this.idyll = Idyll({
@@ -208,7 +205,7 @@ class Main {
     compile(fileContent, {})
       .then(ast => {
         // Get project URL if it exists
-        const tokenPath = getTokenPath(p, this.workingDir);
+        const tokenPath = getTokenPath(this.workingDir);
 
         let url = '';
         try {
@@ -233,12 +230,12 @@ class Main {
           datasets: this.idyll.getDatasets(),
           url: url
         });
+
+        this.store.updateLastOpenedProject(this.filePath);
       })
       .catch(error => {
-        console.log(error);
+        console.log(error, 'Could not open file: ' + this.filePath);
       });
-
-    this.store.updateLastOpenedProject(this.filePath);
   }
 }
 

--- a/src/main/utils/index.js
+++ b/src/main/utils/index.js
@@ -1,9 +1,11 @@
+const p = require('path');
+
 /**
  * Gets the working directory of a file
  * @param {*} p a path module
  * @param {string} filePath the string filePath
  */
-const getWorkingDirectory = (p, filePath) => {
+const getWorkingDirectory = filePath => {
   const slash = p.sep;
   return filePath.substring(0, filePath.lastIndexOf(slash));
 };
@@ -13,9 +15,8 @@ const getWorkingDirectory = (p, filePath) => {
  * @param {*} p a path module
  * @param {string} workingDir the working directory of the file
  */
-const getTokenPath = (p, workingDir) => {
+const getTokenPath = workingDir => {
   const tokenPath = p.join(workingDir, '.idyll', 'token');
-
   return tokenPath;
 };
 

--- a/src/main/utils/index.js
+++ b/src/main/utils/index.js
@@ -1,0 +1,22 @@
+/**
+ * Gets the working directory of a file
+ * @param {*} p a path module
+ * @param {string} filePath the string filePath
+ */
+const getWorkingDirectory = (p, filePath) => {
+  const slash = p.sep;
+  return filePath.substring(0, filePath.lastIndexOf(slash));
+};
+
+/**
+ * Gets the .idyll token of the project
+ * @param {*} p a path module
+ * @param {string} workingDir the working directory of the file
+ */
+const getTokenPath = (p, workingDir) => {
+  const tokenPath = p.join(workingDir, '.idyll', 'token');
+
+  return tokenPath;
+};
+
+module.exports = { getWorkingDirectory, getTokenPath };

--- a/src/main/utils/index.js
+++ b/src/main/utils/index.js
@@ -1,11 +1,9 @@
-const p = require('path');
-
 /**
  * Gets the working directory of a file
  * @param {*} p a path module
  * @param {string} filePath the string filePath
  */
-const getWorkingDirectory = filePath => {
+const getWorkingDirectory = (p, filePath) => {
   const slash = p.sep;
   return filePath.substring(0, filePath.lastIndexOf(slash));
 };
@@ -15,7 +13,7 @@ const getWorkingDirectory = filePath => {
  * @param {*} p a path module
  * @param {string} workingDir the working directory of the file
  */
-const getTokenPath = workingDir => {
+const getTokenPath = (p, workingDir) => {
   const tokenPath = p.join(workingDir, '.idyll', 'token');
   return tokenPath;
 };

--- a/src/render/idyll-display/components/deploy.js
+++ b/src/render/idyll-display/components/deploy.js
@@ -6,12 +6,6 @@ const getRandomId = () => {
   return Math.floor(Math.random() * 10000000000) + 100000000;
 };
 
-const UIMessage = {
-  publishing: 'Currently publishing...',
-  error: 'An error occurred while publishing',
-  published: 'Published!'
-};
-
 class Deploy extends React.PureComponent {
   static contextType = Context;
   constructor(props) {
@@ -86,18 +80,12 @@ class Deploy extends React.PureComponent {
     return (
       // Meta View
       <div className='deploy-view'>
-        <div className='label'>Metadata</div>
+        <div className='label'>METADATA</div>
         <div className='meta-container'>
-          <div className='meta'>Title {this.renderProps('title')}</div>
-          <div className='meta'>
-            Description {this.renderProps('description')}
-          </div>
-          <div className='meta'>
-            Share Image {this.renderProps('shareImageUrl')}
-          </div>
-          <div className='meta'>
-            URL <a href={this.context.url}>{this.context.url}</a>
-          </div>
+          Title {this.renderProps('title')}
+          Description {this.renderProps('description')}
+          Share Image {this.renderProps('shareImageUrl')}
+          URL <a href={this.context.url}>{this.context.url}</a>
         </div>
 
         {/* Publish Button */}
@@ -109,7 +97,7 @@ class Deploy extends React.PureComponent {
           >
             Publish
           </button>
-          <div>{UIMessage[this.context.currProcess]}</div>
+          <div>{this.context.currProcess}</div>
         </div>
       </div>
     );

--- a/src/render/idyll-display/sidebar/index.js
+++ b/src/render/idyll-display/sidebar/index.js
@@ -117,7 +117,7 @@ class Sidebar extends React.PureComponent {
               {this.getStyleView()}
             </div>
             <div className='publish-view'>
-              <h2>Deploy</h2>
+              <h2>Deployment</h2>
               <Deployment />
             </div>
           </div>
@@ -156,9 +156,7 @@ class Sidebar extends React.PureComponent {
     }
 
     return (
-      <div
-        className='sidebar-information'
-      >
+      <div className='sidebar-information'>
         {currentSidebarNode ? (
           <ComponentDetails />
         ) : (

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -6,6 +6,11 @@ import Context from './context';
 const { ipcRenderer } = require('electron');
 const idyllAST = require('idyll-ast');
 
+const PUBLISHING_ERROR = 'Error occurred while publishing: ';
+const PUBLISHING = 'Publishing your project...';
+const PUBLISHED = 'Published!';
+const PROJECT_LOADING = 'Loading project...';
+
 class App extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -47,22 +52,27 @@ class App extends React.PureComponent {
     );
 
     ipcRenderer.on('publishing', (event, message) => {
-      console.log(message);
       this.setState({
-        currProcess: 'publishing'
+        currProcess: PUBLISHING
       });
     });
 
     ipcRenderer.on('pub-error', (event, message) => {
       this.setState({
-        currProcess: 'error'
+        currProcess: PUBLISHING_ERROR + message
       });
     });
 
-    ipcRenderer.on('url', (event, request) => {
+    ipcRenderer.on('loading-project', (event, message) => {
+      this.setState({
+        currProcess: PROJECT_LOADING
+      });
+    });
+
+    ipcRenderer.on('published-url', (event, request) => {
       this.setState({
         url: request.url,
-        currProcess: request.status
+        currProcess: PUBLISHED
       });
     });
 

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -9,7 +9,6 @@ const idyllAST = require('idyll-ast');
 const PUBLISHING_ERROR = 'Error occurred while publishing: ';
 const PUBLISHING = 'Publishing your project...';
 const PUBLISHED = 'Published!';
-const PROJECT_LOADING = 'Loading project...';
 
 class App extends React.PureComponent {
   constructor(props) {
@@ -60,12 +59,6 @@ class App extends React.PureComponent {
     ipcRenderer.on('pub-error', (event, message) => {
       this.setState({
         currProcess: PUBLISHING_ERROR + message
-      });
-    });
-
-    ipcRenderer.on('loading-project', (event, message) => {
-      this.setState({
-        currProcess: PROJECT_LOADING
       });
     });
 

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -57,10 +57,10 @@ class App extends React.PureComponent {
       });
     });
 
-    ipcRenderer.on('url', (event, url) => {
+    ipcRenderer.on('url', (event, request) => {
       this.setState({
-        url: url,
-        currProcess: 'published'
+        url: request.url,
+        currProcess: request.status
       });
     });
 

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -16,7 +16,9 @@ class App extends React.PureComponent {
       componentPropMap: new Map(),
       ast: undefined,
       datasets: undefined,
-      currentSidebarNode: null
+      currentSidebarNode: null,
+      url: '',
+      currProcess: null
     };
 
     this.createComponentMap = this.createComponentMap.bind(this);
@@ -26,7 +28,7 @@ class App extends React.PureComponent {
     // Load in datasets
     ipcRenderer.on(
       'idyll:compile',
-      (event, { datasets, ast, components, path }) => {
+      (event, { datasets, ast, components, path, url }) => {
         console.log(components);
         var componentProps = this.createComponentMap(components);
 
@@ -39,7 +41,7 @@ class App extends React.PureComponent {
           layout: 'centered',
           theme: 'default',
           currProcess: '',
-          url: '' // replace once sqlite db implemented
+          url: url // replace once sqlite db implemented
         });
       }
     );

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -62,9 +62,9 @@ class App extends React.PureComponent {
       });
     });
 
-    ipcRenderer.on('published-url', (event, request) => {
+    ipcRenderer.on('published-url', (event, url) => {
       this.setState({
-        url: request.url,
+        url: url,
         currProcess: PUBLISHED
       });
     });

--- a/src/stylesheets/app.css
+++ b/src/stylesheets/app.css
@@ -21,7 +21,6 @@ html {
   width: calc(100vw + 300px);
 }
 
-
 .output-container {
   /* grid-row: 2; */
   /* grid-column: 1 / 2; */
@@ -94,7 +93,7 @@ button.loader:hover {
   background-image: none !important;
   background-color: #222 !important;
   color: white !important;
-  opacity: 1 !important;;
+  opacity: 1 !important;
 }
 
 .author-view-button:focus {
@@ -148,14 +147,30 @@ button.loader:hover {
 
 .meta-container {
   text-align: right;
-  width: 80%;
+  width: 90%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: baseline;
+  column-gap: 7px;
+}
+
+.meta-container a {
+  text-align: left;
+}
+
+.deploy-view {
+  display: grid;
 }
 
 .publish-button-container {
-  width: 50%;
-  margin: 0 auto;
+  justify-self: center;
   text-align: center;
 }
+
+#publish-button {
+  width: 150px;
+}
+
 .prop-input {
   margin: 0;
   width: 100%;
@@ -180,7 +195,6 @@ button.loader:hover {
   max-width: 800px;
   margin: 0 auto;
 }
-
 
 .editable-text:hover {
   margin-left: -12px;

--- a/src/stylesheets/app.css
+++ b/src/stylesheets/app.css
@@ -168,7 +168,7 @@ button.loader:hover {
 }
 
 #publish-button {
-  width: 150px;
+  min-width: 150px;
 }
 
 .prop-input {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,7 +1,53 @@
+const DataStore = require('../src/main/data-store/data-store');
 const expect = require('expect');
 
-describe('first test', () => {
-  it('should run', () => {
-    expect(true).toBe(true);
+jest.mock('fs', () => {
+  return {
+    readFileSync: path => {
+      throw 'testing error';
+    },
+    writeFileSync: (path, contents) => {}
+  };
+});
+
+jest.mock('path', () => ({
+  join: (dir, file) => dir + '/' + file
+}));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => 'path' },
+  remote: { app: { getPath: () => 'path' } }
+}));
+
+describe('DataStore tests', () => {
+  let store;
+  beforeEach(() => {
+    store = new DataStore();
+    jest.resetModules();
   });
+
+  it('should initialize a new store if the store file does not exist', () => {
+    const data = store.data;
+    expect(data.tokenUrls).toEqual([]);
+    expect(data.lastOpenedProject).toEqual({
+      filePath: null,
+      lastOpened: null
+    });
+    expect(store.path).toEqual('path/project-data.json');
+  });
+
+  // it('should initialize the store with the project file contents', () => {
+  //   jest.mock('fs', () => {
+  //     return {
+  //       readFileSync: path => ({
+  //         tokenUrls: [{ token: 'abc', url: 'path/to/url.idyll' }],
+  //         lastOpenedProject: {
+  //           filePath: 'path/to/url.idyll',
+  //           lastOpened: 11282019
+  //         }
+  //       })
+  //     };
+  //   });
+
+  // });
 });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,14 +1,5 @@
-const DataStore = require('../src/main/data-store/data-store');
+const error = require('../src/error');
 const expect = require('expect');
-
-jest.mock('fs', () => {
-  return {
-    readFileSync: path => {
-      throw 'testing error';
-    },
-    writeFileSync: (path, contents) => {}
-  };
-});
 
 jest.mock('path', () => ({
   join: (dir, file) => dir + '/' + file
@@ -19,14 +10,25 @@ jest.mock('electron', () => ({
   remote: { app: { getPath: () => 'path' } }
 }));
 
-describe('DataStore tests', () => {
-  let store;
+describe('DataStore initialization tests', () => {
   beforeEach(() => {
-    store = new DataStore();
     jest.resetModules();
   });
 
   it('should initialize a new store if the store file does not exist', () => {
+    jest.doMock('fs', () => {
+      return {
+        readFileSync: path => {
+          throw 'testing error';
+        },
+        writeFileSync: (path, contents) => {}
+      };
+    });
+
+    const DataStore = require('../src/main/data-store/data-store');
+    const store = new DataStore();
+
+    // test data and path initiali values
     const data = store.data;
     expect(data.tokenUrls).toEqual([]);
     expect(data.lastOpenedProject).toEqual({
@@ -36,18 +38,163 @@ describe('DataStore tests', () => {
     expect(store.path).toEqual('path/project-data.json');
   });
 
-  // it('should initialize the store with the project file contents', () => {
-  //   jest.mock('fs', () => {
-  //     return {
-  //       readFileSync: path => ({
-  //         tokenUrls: [{ token: 'abc', url: 'path/to/url.idyll' }],
-  //         lastOpenedProject: {
-  //           filePath: 'path/to/url.idyll',
-  //           lastOpened: 11282019
-  //         }
-  //       })
-  //     };
-  //   });
+  it('should initialize the store with the project file contents', () => {
+    jest.doMock('fs', () => {
+      return {
+        readFileSync: path =>
+          JSON.stringify({
+            tokenUrls: [{ token: 'abc', url: 'path/to/url.idyll' }],
+            lastOpenedProject: {
+              filePath: 'another/path/to/url.idyll',
+              lastOpened: 11282019
+            }
+          })
+        // no need to mock writeFileSync
+      };
+    });
 
-  // });
+    const DataStore = require('../src/main/data-store/data-store');
+    const store = new DataStore();
+
+    const data = store.data;
+    expect(data.tokenUrls).toEqual([
+      { token: 'abc', url: 'path/to/url.idyll' }
+    ]);
+    expect(data.lastOpenedProject).toEqual({
+      filePath: 'another/path/to/url.idyll',
+      lastOpened: 11282019
+    });
+    expect(store.path).toEqual('path/project-data.json');
+  });
+});
+
+describe('DataStore function tests', () => {
+  let store;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.doMock('fs', () => ({
+      readFileSync: path =>
+        JSON.stringify({
+          tokenUrls: [
+            { token: 'abc', url: 'path/to/url.idyll' },
+            {
+              token: '123',
+              url: '123/abc.idyll'
+            }
+          ],
+          lastOpenedProject: {
+            filePath: 'another/path/to/url.idyll',
+            lastOpened: 11282019
+          }
+        }),
+      writeFileSync: () => {}
+    }));
+
+    const DataStore = require('../src/main/data-store/data-store');
+    store = new DataStore();
+  });
+
+  it('getTokenUrlByToken: should return a valid tokenUrl pair', () => {
+    const result = store.getTokenUrlByToken('123');
+    expect(result).toEqual({ token: '123', url: '123/abc.idyll' });
+  });
+
+  it('getTokenUrlByToken: should throw an InvalidParameterError on null and undefined', () => {
+    try {
+      store.getTokenUrlByToken(null);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+
+    try {
+      store.getTokenUrlByToken(undefined);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+  });
+
+  it('getTokenUrlByToken: should return new copy of store data', () => {
+    const result = store.getTokenUrlByToken('123');
+    result.token = '456';
+
+    expect(result.token).toBe('456');
+    expect(store.getTokenUrlByToken('456')).toBe(null);
+  });
+
+  it('getLastSessionProjectPath: should return the last opened project', () => {
+    expect(store.getLastSessionProjectPath()).toBe('another/path/to/url.idyll');
+  });
+
+  it('addTokenUrlPair: should update this.data with the new token pair', () => {
+    store.addTokenUrlPair('a-new-url.com', 'newToken');
+
+    expect(store.getTokenUrlByToken('newToken')).toEqual({
+      token: 'newToken',
+      url: 'a-new-url.com'
+    });
+    expect(store.data.tokenUrls).toEqual([
+      { token: 'abc', url: 'path/to/url.idyll' },
+      {
+        token: '123',
+        url: '123/abc.idyll'
+      },
+      { token: 'newToken', url: 'a-new-url.com' }
+    ]);
+  });
+
+  it('addTokenUrlPair: should throw an InvalidParameterError on null and undefined', () => {
+    try {
+      store.addTokenUrlPair(null, null);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+
+    try {
+      store.addTokenUrlPair(undefined, undefined);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+
+    try {
+      store.addTokenUrlPair('123', undefined);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+
+    try {
+      store.addTokenUrlPair('345', null);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+  });
+
+  it('updateLastOpenedProject: should update the last opened project', () => {
+    const expected = '/new/project/path.idyll';
+    store.updateLastOpenedProject(expected);
+    expect(store.getLastSessionProjectPath()).toBe(expected);
+  });
+
+  it('updateLastOpenedProject: should throw an InvalidParameterError on null or undefined', () => {
+    try {
+      store.updateLastOpenedProject(null);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+
+    try {
+      store.updateLastOpenedProject(undefined);
+      expect(true).toBeFalsy(); // should never be reached
+    } catch (err) {
+      expect(err.name).toBe('InvalidParameterError');
+    }
+  });
 });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,0 +1,7 @@
+const expect = require('expect');
+
+describe('first test', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This addresses issue #12 and adds persistent storage to the app. When the app is opened, it'll read from the project-data.json file located in the app's directory and load the last opened project. If that project's token and url is stored in the project-data file, it'll also display the project URL under the "deployment" section.

![project-open](https://user-images.githubusercontent.com/24836994/70117422-55a41980-161a-11ea-94db-66a8983d852f.gif)


Urls stored should also persist and show up when switching between projects.


![open-existing](https://user-images.githubusercontent.com/24836994/70117450-62287200-161a-11ea-8fd0-f7891c65741c.gif)


This also introduces a Jest testing suite that can be run using ```npm run test``` or ```npm run test:watch```.  There is currently only one test file.

![Hnet-image](https://user-images.githubusercontent.com/24836994/70117876-63a66a00-161b-11ea-8832-f986bc35f2c2.gif)

Also, some formatting/styling for the deployment section of the sidebar is fixed to more accurately reflect the mock ups.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, project urls do not persist when you switch between projects or on project load. Also, when the app launches, it defaults to the "Select" screen. There is also no testing suite.


* **What is the new behavior (if this is a feature change)?**
Main now updates a data store that serializes its contents and writes to the project-data.json file. The data schema is: 

``` { tokenUrls: [{token: string, url: string}, ...], lastOpenedProject: {filePath: string, lastOpened: Date}}```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.