### PR TITLE
updates electron to fix the static content filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5852,9 +5852,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-8.5.5.tgz",
-      "integrity": "sha512-e355H+tRDial0m+X2v+l+0SnaATAPw4sNjv9qmdk/6MJz/glteVJwVJEnxTjPfEELIJSChrBWDBVpjdDvoBF4Q==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-11.1.1.tgz",
+      "integrity": "sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==",
       "requires": {
         "@electron/get": "^1.0.1",
         "@types/node": "^12.0.12",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "draft-js": "^0.11.7",
-    "electron": "^8.5.5",
+    "electron": "^11.1.1",
     "idyll": "^5.0.0",
     "idyll-compiler": "^4.0.14",
     "idyll-components": "^4.0.2",

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -175,16 +175,14 @@ class Main {
     });
 
     // filter to catch all requests to static folder
-    const staticContentFilter = { urls: ['*://*/static/*'] };
     this.mainWindow.webContents.session.webRequest.onBeforeRequest(
-      staticContentFilter,
       (details, callback) => {
         const { url } = details;
         if (url.indexOf(`${this.electronWorkingDir}/static/`) > -1) {
           const localURL = url.replace(
             this.electronWorkingDir,
             this.workingDir
-          );
+            );
           callback({
             cancel: false,
             redirectURL: encodeURI(localURL)

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -182,7 +182,7 @@ class Main {
           const localURL = url.replace(
             this.electronWorkingDir,
             this.workingDir
-            );
+          );
           callback({
             cancel: false,
             redirectURL: encodeURI(localURL)

--- a/src/render/idyll-display/components/author-tool-buttons.js
+++ b/src/render/idyll-display/components/author-tool-buttons.js
@@ -111,8 +111,6 @@ class AuthorToolButtons extends React.PureComponent {
     return dropTarget(
       <div className='component-debug-view'>
         <div
-          contentEditable={true}
-          suppressContentEditableWarning={true}
           ref={ref => (this._componentRef = ref)}>
           {props.component}
         </div>


### PR DESCRIPTION
This updates our version of electron to v11. It fixes a regression that appears to have happened where images from an idyll project's static folder wouldn't load.

With this PR images now load correctly. I also snuck in a small tweak so that all components are no longer wrapped in a content editable, which is no longer necessary given how we are handling text and code block editing. 