### PR TITLE
fix publish on windows

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -170,7 +170,7 @@ class Main {
       let files = await readdir(buildDir);
 
       let formData = files.reduce((acc, f) => {
-        acc[p.relative(buildDir, f)] = fs.createReadStream(f);
+        acc[p.relative(buildDir, f).replace(/\\/g, '/')] = fs.createReadStream(f);
         return acc;
       }, {});
       formData['token'] = token;


### PR DESCRIPTION
Force use of linux-style filepaths when sending filenames to idyll.pub API server