### PR TITLE
Sidebar cleanup

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,10 @@
 export const EXECUTE_KEY = 'Enter';
 
+export const TEXT = 'Text';
 export const INPUT = 'Input';
 export const LAYOUT = 'Layout';
 export const LOGIC = 'Logic';
-export const PRESENTATION = 'Presentation';
+export const PRESENTATION = 'Display';
 export const HELPERS = 'Helpers';
 
 export const COMPONENTS_CATEGORY_MAP = new Map([
@@ -24,7 +25,7 @@ export const COMPONENTS_CATEGORY_MAP = new Map([
   ['stepper', LAYOUT],
   ['step', LAYOUT],
   ['stepper-control', LAYOUT],
-  ['text-container', LAYOUT],
+  ['text-container', TEXT],
   ['conditional', LOGIC],
   ['loop', LOGIC],
   ['switch', LOGIC],
@@ -38,13 +39,13 @@ export const COMPONENTS_CATEGORY_MAP = new Map([
   ['gist', PRESENTATION],
   ['graphic', PRESENTATION],
   ['header', PRESENTATION],
-  ['h1', PRESENTATION],
-  ['h2', PRESENTATION],
-  ['h3', PRESENTATION],
-  ['h4', PRESENTATION],
-  ['h5', PRESENTATION],
-  ['h6', PRESENTATION],
-  ['link', PRESENTATION],
+  ['h1', TEXT],
+  ['h2', TEXT],
+  ['h3', TEXT],
+  ['h4', TEXT],
+  ['h5', TEXT],
+  ['h6', TEXT],
+  ['link', TEXT],
   ['svg', PRESENTATION],
   ['table', PRESENTATION],
   ['tweet', PRESENTATION],
@@ -55,6 +56,7 @@ export const COMPONENTS_CATEGORY_MAP = new Map([
   ['preload', HELPERS]
 ]);
 
-export const EXCLUDED_COMPONENTS = ['generateHeaders'];
+
+export const EXCLUDED_COMPONENTS = ['generateHeaders', 'fixed', 'inline', 'scroller', 'step', 'stepper-control', 'case', 'default', 'graphic', 'analytics', 'meta', 'preload'];
 
 export const DEBOUNCE_PROPERTY_MILLISECONDS = 250;

--- a/src/render/idyll-display/components/component-view/component-view.js
+++ b/src/render/idyll-display/components/component-view/component-view.js
@@ -6,6 +6,7 @@ import {
   LAYOUT,
   LOGIC,
   PRESENTATION,
+  TEXT,
   HELPERS,
   EXCLUDED_COMPONENTS
 } from '../../../../constants';
@@ -27,11 +28,12 @@ export const WrappedComponentView = withContext(
       };
 
       this.categoriesMap = {
+        [TEXT]: [],
         [INPUT]: [],
+        [PRESENTATION]: [],
         [LAYOUT]: [],
         [LOGIC]: [],
-        [PRESENTATION]: [],
-        [HELPERS]: [],
+        // [HELPERS]: [],
         Custom: []
       };
 
@@ -39,12 +41,14 @@ export const WrappedComponentView = withContext(
         this.props.context.components &&
         this.props.context.components.length > 0
       ) {
-        this.props.context.components.map(component => {
+        this.props.context.components.filter(component => {
+          return !EXCLUDED_COMPONENTS.includes(component.name);
+        }).map(component => {
           if (COMPONENTS_CATEGORY_MAP.has(component.name)) {
             this.categoriesMap[
               COMPONENTS_CATEGORY_MAP.get(component.name)
             ].push(component);
-          } else if (!EXCLUDED_COMPONENTS.includes(component.name)) {
+          } else {
             this.categoriesMap.Custom.push(component);
           }
         });
@@ -57,7 +61,7 @@ export const WrappedComponentView = withContext(
       const filteredResults = this.props.context.components.filter(
         component => {
           const name = formatString(component.name).toLowerCase();
-          return name.startsWith(value.toLowerCase());
+          return name.includes(value.toLowerCase());
         }
       );
 

--- a/src/render/idyll-display/components/component-view/component.js
+++ b/src/render/idyll-display/components/component-view/component.js
@@ -30,7 +30,7 @@ class Component extends React.PureComponent {
           opacity: isDragging ? 0.5 : 1
         }}
         className='component'>
-        {name.toLowerCase() === 'text container' ? 'Paragraph' : name}
+        {name.toLowerCase ? (name.toLowerCase() === 'text container' ? 'Paragraph' : name) : name}
       </div>
     );
   }

--- a/src/render/idyll-display/components/component-view/component.js
+++ b/src/render/idyll-display/components/component-view/component.js
@@ -30,7 +30,7 @@ class Component extends React.PureComponent {
           opacity: isDragging ? 0.5 : 1
         }}
         className='component'>
-        {name}
+        {name.toLowerCase() === 'text container' ? 'Paragraph' : name}
       </div>
     );
   }

--- a/src/render/idyll-display/components/deploy.js
+++ b/src/render/idyll-display/components/deploy.js
@@ -85,17 +85,7 @@ class Deploy extends React.PureComponent {
           <div>Title {this.renderProps('title')}</div>
           <div>Description {this.renderProps('description')}</div>
           <div>Share Image {this.renderProps('shareImageUrl')}</div>
-          {this.context.url ? (
-            <div className='url-display'>
-              URL:{' '}
-              <a
-                href={this.context.url}
-                style={{ textTransform: 'none' }}
-                target='_blank'>
-                {this.context.url}
-              </a>
-            </div>
-          ) : null}
+
         </div>
 
         {/* Publish Button */}
@@ -109,7 +99,18 @@ class Deploy extends React.PureComponent {
             disabled={this.context.currentProcess === 'publishing'}>
             Publish
           </button>
-          <div>{this.context.currentProcess}</div>
+          <div className={'deploy-process-output'}>{this.context.currentProcess}</div>
+          {this.context.url ? (
+            <div className='url-display'>
+              URL:{' '}
+              <a
+                href={this.context.url}
+                style={{ textTransform: 'none' }}
+                target='_blank'>
+                {this.context.url}
+              </a>
+            </div>
+          ) : null}
         </div>
       </div>
     );

--- a/src/render/idyll-display/sidebar/index.js
+++ b/src/render/idyll-display/sidebar/index.js
@@ -43,6 +43,7 @@ class Sidebar extends React.PureComponent {
           Theme
           <select
             onChange={this.handleThemeChange.bind(this)}
+            disabled={true}
             value={this.context.theme}>
             {Object.keys(themes)
               .filter((d) => !['__esModule', 'none'].includes(d))
@@ -58,6 +59,7 @@ class Sidebar extends React.PureComponent {
         <div className='layout-container'>
           Layout
           <select
+            disabled={true}
             onChange={this.handleLayoutChange.bind(this)}
             value={this.context.layout}>
             {Object.keys(layouts)

--- a/src/stylesheets/app.css
+++ b/src/stylesheets/app.css
@@ -72,8 +72,6 @@ html {
     border-radius: 10px;
     transition: all 0.25s;
     box-sizing: border-box;
-    position: relative;
-    top: 0;
 }
 
 .idyll-studio-drop-target.is-dragging {
@@ -85,7 +83,6 @@ html {
 .idyll-studio-drop-target.is-dragging.is-over {
   height: 55px;
   border: solid 0.5px #999;
-  top: -10px;
 }
 
 button.loader, button.creator {
@@ -264,7 +261,9 @@ button {
   cursor: auto;
 }
 
-.meta-container {
+.meta-container,
+.deploy-view,
+.deploy-process-output {
   /* text-align: right;
   width: 90%;
   display: grid;
@@ -276,7 +275,9 @@ button {
 }
 .meta-container > div,
 .theme-container,
-.layout-container {
+.layout-container,
+.deploy-view .url-display,
+.deploy-process-output {
   margin-bottom: 1em;
   font-weight: 300;
   font-size: 0.8em;
@@ -300,7 +301,7 @@ button {
   text-align: left;
 }
 
-.meta-container .url-display {
+.deploy-view .url-display {
   font-family: monospace;
 }
 
@@ -365,6 +366,10 @@ input.prop-input[type="text"] {
   background-color: #666666;
   margin: 0 1em;
   padding: 0.66em 0.66em;
+}
+
+.editable-text {
+  margin-bottom: 16px;
 }
 
 .editable-text:hover {


### PR DESCRIPTION
- Filters the components so only the ones that work well with default props appear. 
- Adds a new `Text` category. 
- Renames `Text Container` to `Paragraph` 
- Disables theme/layout selectors

fixes #87