### PR TITLE
duplicate components

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -116,6 +116,9 @@ class Main {
     } while (fs.existsSync(copyPath))
 
     fs.copyFileSync(componentPath, copyPath);
+    const infile = fs.readFileSync(componentPath, 'utf-8').toString();
+    const outfile = infile.replace(/from '\.\//g, "from 'idyll-components/dist/cjs/").replace(/from "\.\//g, "from \"idyll-components/dist/cjs/").replace(/require\('\.\//g, "require('idyll-components/dist/cjs/").replace(/require\("\.\//g, "require(\"idyll-components/dist/cjs/");
+    fs.writeFileSync(copyPath, outfile);
     const newComponent = { path: copyPath, name: `${p.basename(copyPath).replace(/\.jsx?/g, '')}` };
 
     this.mainWindow.webContents.send('components:add', newComponent);

--- a/src/render/idyll-display/components/component-view/component-accordion.js
+++ b/src/render/idyll-display/components/component-view/component-accordion.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Component from './component';
 import { Arrow } from './icons/arrow';
 
-class ComponentAccordion extends React.PureComponent {
+class ComponentAccordion extends React.Component {
   constructor(props) {
     super(props);
 
@@ -24,6 +24,26 @@ class ComponentAccordion extends React.PureComponent {
       isClosed: !this.state.isClosed
     });
   };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.components.length !== this.props.components.length) {
+      const scrollHeight = this._panelRef.current.scrollHeight;
+
+      this.setState({
+        maxHeight: this.state.maxHeight === '0px' ? '0px' : `${scrollHeight}px`
+      });
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (this.props.components.length !== nextProps.components.length) {
+      return true;
+    }
+    else if (nextState.isClosed !== this.state.isClosed || nextState.maxHeight !== this.state.maxHeight) {
+      return true;
+    }
+    return false;
+  }
 
   render() {
     const { category, components, isCustom } = this.props;
@@ -49,7 +69,7 @@ class ComponentAccordion extends React.PureComponent {
 
           <div className='accordion-component'>
             {(components || []).map((component, i) => {
-              return <Component key={i} component={component} isCustom={isCustom} />;
+              return <Component key={component.name} component={component} isCustom={isCustom} />;
             })}
           </div>
         </div>

--- a/src/render/idyll-display/components/component-view/component-accordion.js
+++ b/src/render/idyll-display/components/component-view/component-accordion.js
@@ -49,6 +49,10 @@ class ComponentAccordion extends React.Component {
     const { category, components, isCustom } = this.props;
     const { isClosed } = this.state;
 
+    components.sort((a, b) => {
+      return a.name - b.name;
+    })
+
     return (
       <div className='component-category'>
         <button onClick={this.handleClick} className='accordion-category'>

--- a/src/render/idyll-display/components/component-view/component-view.js
+++ b/src/render/idyll-display/components/component-view/component-view.js
@@ -25,9 +25,14 @@ export const WrappedComponentView = withContext(
 
       this.state = {
         searchValue: '',
-        filteredComponents: []
+        filteredComponents: [],
+        componentMaps: this.buildComponentMaps()
       };
 
+
+    }
+
+    buildComponentMaps () {
       this.categoriesMap = {
         [TEXT]: [],
         [INPUT]: [],
@@ -55,6 +60,8 @@ export const WrappedComponentView = withContext(
           }
         });
       }
+
+      return this.categoriesMap;
     }
 
     searchComponents = e => {
@@ -86,7 +93,7 @@ export const WrappedComponentView = withContext(
           <ComponentAccordion
             category={category}
             isCustom={category === 'Custom'}
-            key={'component_category:' + i}
+            key={'component_category:' + category}
             components={this.categoriesMap[category]}
           />
         );
@@ -103,7 +110,7 @@ export const WrappedComponentView = withContext(
               id='filtered-search-results'
               key={'component-container:' + i}>
               <Component
-                key={i}
+                key={component.name}
                 component={component}
                 isCustom={this.categoriesMap.Custom.includes(component)}
                 searchValue={this.state.searchValue}
@@ -114,9 +121,18 @@ export const WrappedComponentView = withContext(
       }
     };
 
+    componentDidUpdate (prevProps) {
+      if (this.props.context.components.length !== prevProps.context.components.length) {
+        this.setState({
+          componentMaps: this.buildComponentMaps()
+        })
+      }
+    }
+
     render() {
       return (
         <div className='component-view'>
+          <div style={{color: '#999', fontSize: 11, fontWeight: 'bold', marginBottom: 18, lineHeight: 1.2}}>Drag-and-drop components onto the document.</div>
           <SearchBarInput
             placeholder='Search Components'
             onChange={this.searchComponents}

--- a/src/render/idyll-display/components/component-view/component.js
+++ b/src/render/idyll-display/components/component-view/component.js
@@ -3,11 +3,6 @@ import { DragSource } from 'react-dnd';
 import { formatString } from '../../utils';
 const { ipcRenderer } = require('electron');
 
-
-
-
-
-
 const nameMap = {
   'text container': 'Paragraph',
   'display': 'Display Value'
@@ -24,7 +19,7 @@ class Component extends React.PureComponent {
   }
   handleDuplicateClick() {
     const { component } = this.props;
-    // open(component.path);
+    ipcRenderer.send('client:duplicateComponent', component);
   }
 
   render() {
@@ -53,14 +48,14 @@ class Component extends React.PureComponent {
             {name.toLowerCase ? (nameMap[name.toLowerCase()] || name) : name}
           </div>
           {
-            (isDragging || !isCustom) ? null : (
+            isDragging ? null : (
               <div>
-                <div className="component-edit" onClick={this.handleEditClick.bind(this)}>
+                { isCustom ? <div className="component-edit" onClick={this.handleEditClick.bind(this)}>
                   Edit
-                </div>
-                {/* <div className="component-duplicate" onClick={this.handleEditClick.bind(this)}>
+                </div> : null}
+                <div className="component-duplicate" onClick={this.handleDuplicateClick.bind(this)}>
                   Duplicate
-                </div> */}
+                </div>
               </div>
             )
           }

--- a/src/render/idyll-display/components/component-view/component.js
+++ b/src/render/idyll-display/components/component-view/component.js
@@ -44,7 +44,7 @@ class Component extends React.PureComponent {
           opacity: isDragging ? 0.5 : 1
         }}
         className='component'>
-          <div>
+          <div className='component-name'>
             {name.toLowerCase ? (nameMap[name.toLowerCase()] || name) : name}
           </div>
           {

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -58,6 +58,8 @@ class App extends React.PureComponent {
           return;
         }
 
+        components = components.filter(c => c.name.toLowerCase() !== '.ds_store');
+
         var componentProps = this.createComponentMap(components);
 
         this._undoStash = copy(ast);
@@ -84,6 +86,16 @@ class App extends React.PureComponent {
 
     ipcRenderer.on('data:import', () => {
       this._dataImportCb && this._dataImportCb();
+    });
+
+    ipcRenderer.on('components:add', (event, component) => {
+      const newComponents = [...this.state.components, component];
+      const componentPropMap = this.createComponentMap(newComponents);
+
+      this.setState({
+        components: newComponents,
+        componentPropMap: componentPropMap
+      });
     });
 
     window.addEventListener(

--- a/src/stylesheets/app.css
+++ b/src/stylesheets/app.css
@@ -446,6 +446,7 @@ input.prop-input[type="text"] {
   width: 100%;
   display: flex;
   justify-content: space-between;
+  white-space: nowrap;
 }
 
 .component-edit, .component-duplicate {

--- a/test/components.test.js
+++ b/test/components.test.js
@@ -296,7 +296,7 @@ describe('<ComponentAccordion />', () => {
     button.simulate('click');
     expect(component.find(Arrow).props().isClosed).toBeFalsy();
 
-    const componentContents = component.find('div.component');
+    const componentContents = component.find('div.component-name');
     expect(componentContents).toHaveLength(3);
     expect(componentContents.at(0).text()).toBe('A');
     expect(componentContents.at(1).text()).toBe('B');
@@ -314,7 +314,7 @@ describe('<Component />', () => {
       </DndProvider>
     );
 
-    const componentName = component.find('div.component');
+    const componentName = component.find('div.component-name');
     expect(componentName.text()).toBe('Abc');
   });
 
@@ -328,7 +328,7 @@ describe('<Component />', () => {
     const componentBold = component.find('strong');
     expect(componentBold.text()).toBe('A');
 
-    const componentName = component.find('div.component');
+    const componentName = component.find('div.component-name');
     expect(componentName.text()).toBe('Abc');
   });
 });


### PR DESCRIPTION
Related to https://github.com/idyll-lang/idyll-studio/pull/97, this PR adds a "duplicate" button to the components in the sidebar. 

Regardless of what category the component being duplicated belongs to, the new copy will be added to the "custom" group. ~There is one small bug still where components that import internal component helpers (e.g. `import GenerateHeaders from './generateHeaders';`) throw errors because moving from the `node_modules` folder to the `<working-directory>/components` folder changes that import path.~

Edit: fixed the above bug